### PR TITLE
Allow zero values in theme

### DIFF
--- a/lib/src/Theme.js
+++ b/lib/src/Theme.js
@@ -79,7 +79,7 @@ class Theme {
     if (detectTheming(value)) {
       // Handle the basic use case
       const v = this.def[value.substr(1)];
-      if (v) {
+      if (v !== undefined && v !== null) {
         return v;
       }
 


### PR DESCRIPTION
This is to allow zero-values in themes, for example `padding: 0`.